### PR TITLE
making findnetworkentriessingleregion public

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -507,7 +507,7 @@ public class LocationIndexTree implements LocationIndex {
         return min;
     }
 
-    final void findNetworkEntriesSingleRegion(TIntHashSet storedNetworkEntryIds, double queryLat, double queryLon) {
+    public final void findNetworkEntriesSingleRegion(TIntHashSet storedNetworkEntryIds, double queryLat, double queryLon) {
         long keyPart = createReverseKey(queryLat, queryLon);
         fillIDs(keyPart, START_POINTER, storedNetworkEntryIds, 0);
     }


### PR DESCRIPTION
To allow use of `findNetworkEntriesSingleRegion` when extending `LocationIndexTree` to create different search algorithms than `findNetworkEntries`. Use cases are e.g. map-matching and custom implementations e.g. [here](https://github.com/graphhopper/map-matching/pull/67).